### PR TITLE
calc_distr and boltzmann_weights options

### DIFF
--- a/FRETpredict/FRET.py
+++ b/FRETpredict/FRET.py
@@ -401,8 +401,10 @@ class FRETpredict(Operations):
                     # Warning for Z < Z_cutoff
                     #print('\nZ < Z_cutoff')
 
-                    # If Z value < cutoff then create an empty array for k2 values with same dimension as Z array, to save
-                    allk2 = np.zeros_like(allZ, dtype=float)
+
+                    if self.calc_distr:
+                        # If Z value < cutoff then create an empty array for k2 values with same dimension as Z array, to save
+                        allk2 = np.zeros_like(allZ, dtype=float)
 
                     # Skip to next iteration
                     continue
@@ -460,9 +462,8 @@ class FRETpredict(Operations):
                     # Write the calculated distribution for each frame in the H5PY dataset
                     try:
                         distributions[frame_ndx] = distribution
-
-                except:
-                    continue
+                    except:
+                        continue
 
         if self.calc_distr:
             # Close H5PY file

--- a/FRETpredict/FRET.py
+++ b/FRETpredict/FRET.py
@@ -146,11 +146,11 @@ class FRETpredict(Operations):
         self.rax = np.linspace(self.rmin, self.rmax, self.nr)
         self.output_prefix = kwargs.get('output_prefix', 'res')
         self.load_file = kwargs.get('load_file', False)
-        self.weights = kwargs.get('weights', False)
+        self.weights = kwargs.get('weights', None)
         self.user_weights = kwargs.get('user_weights', None)
         self.stdev = kwargs.get('filter_stdev', 0.02)
         self.verbose = kwargs.get('verbose', False)
-        self.calc_distr = kwargs.get('calc_distr', True)
+        self.calc_distr = kwargs.get('calc_distr', False)
 
         # Logging set up
         if self.verbose:
@@ -502,69 +502,42 @@ class FRETpredict(Operations):
 
         """
 
-        output_reweight_prefix = kwargs.get('reweight_prefix', self.output_prefix)
+        reweight_output_prefix = kwargs.get('reweight_output_prefix', self.output_prefix)
 
         # Load <k2> distribution from file
         k2 = np.loadtxt(self.output_prefix + '-k2-{:d}-{:d}.dat'.format(self.residues[0], self.residues[1]))
 
-        # Check if user provided per-frame weights
-        # If the user want the average to be unweighted
-        if self.user_weights is None:
-
-            # Check if weights is an array
-            if isinstance(self.weights, np.ndarray):
-
-                # Check if user_weights size corresponds to the total number of frames
-                if self.weights.size != k2.size:
-
-                    # Warning log
-                    logging.debug('Weights array has size {} whereas the number of frames is {}'.
-                                 format(self.weights.size, k2.size))
-
-                    # Raise error
-                    raise ValueError('Weights array has size {} whereas the number of frames is {}'.
-                                     format(self.weights.size, k2.size))
-
-            # If we want the average to be unweighted
-            elif not self.weights:
-
-                # Associate every k2 instance with a unitary weight
-                self.weights = np.ones(k2.size)
-
-        # If the user provided per-frame weights
-        elif self.user_weights is not None:
-
-            # Check if user_weights is an array
-            if isinstance(self.user_weights, np.ndarray):
-
-                # Check if user_weights size corresponds to the total number of frames
-                if self.user_weights.size != k2.size:
-
-                    # Warning log
-                    logging.debug('User weights array has size {} whereas the number of frames is {}'.
-                                 format(self.user_weights.size, k2.size))
-
-                    # Raise error
-                    raise ValueError('User weights array has size {} whereas the number of frames is {}'.
-                                     format(self.user_weights.size, k2.size))
-
-                # Obtain dye-protein weights from FRETpredict calculations
-                dye_protein_weights = np.genfromtxt(
-                        self.output_prefix + '-w_s-{:d}-{:d}.dat'.format(self.residues[0], self.residues[1]))
-
-                # Combine dye-protein weights with user provided weights
-                self.weights = (dye_protein_weights * self.user_weights) / np.linalg.norm(
-                        dye_protein_weights * self.user_weights, ord=1)
-
-            # Other options will raise errors
-            else:
-
+        # Check if weights is an array
+        if isinstance(self.weights, np.ndarray):
+            # Check if user_weights size corresponds to the total number of frames
+            if self.weights.size != k2.size:
                 # Warning log
-                logging.debug('User weights argument should be a numpy array')
-
+                logging.debug('Weights array has size {} whereas the number of frames is {}'.
+                             format(self.weights.size, k2.size))
                 # Raise error
-                raise ValueError('User weights argument should be a numpy array')
+                raise ValueError('Weights array has size {} whereas the number of frames is {}'.
+                                 format(self.weights.size, k2.size))
+        # If we don't want to reweight based on dye-protein interactions
+        else:
+            self.weights = np.ones(k2.size)
 
+        # Check if user_weights is an array
+        if isinstance(self.user_weights, np.ndarray):
+            # Check if user_weights size corresponds to the total number of frames
+            if self.user_weights.size != k2.size:
+                # Warning log
+                logging.debug('User weights array has size {} whereas the number of frames is {}'.
+                             format(self.user_weights.size, k2.size))
+                # Raise error
+                raise ValueError('User weights array has size {} whereas the number of frames is {}'.
+                                 format(self.user_weights.size, k2.size))
+        # If we don't want to reweight based on dye-protein interactions
+        elif self.user_weights is None:
+            self.user_weights = np.ones(k2.size)
+
+        # Combine dye-protein weights with user provided weights
+        weights = self.weights * self.user_weights
+        weights = weights / np.sum(weights)
 
         if self.calc_distr:
             # Read data from H5PY file
@@ -574,7 +547,7 @@ class FRETpredict(Operations):
             distributions = f.get('distributions')
 
             # Calculate the sum of the weighted distribution
-            distribution = np.nansum(distributions * self.weights.reshape(-1, 1), 0)
+            distribution = np.nansum(distributions * weights.reshape(-1, 1), 0)
 
             # Calculate smoothed distance distribution
             frame_inv_distr = np.fft.ifft(distribution) * np.fft.ifft(np.exp(-0.5 * (self.rax / self.stdev) ** 2))
@@ -601,16 +574,16 @@ class FRETpredict(Operations):
         # Create DataFrame of weighted averaged values
         else:
 
-            df = pd.DataFrame([self.weightedAvgSDSE(k2[np.isfinite(k2)], self.weights[np.isfinite(k2)]),
-                               self.weightedAvgSDSE(estatic[np.isfinite(k2)], self.weights[np.isfinite(k2)]),
-                               self.weightedAvgSDSE(edynamic1[np.isfinite(k2)], self.weights[np.isfinite(k2)]),
-                               self.weightedAvgSDSE(edynamic2[np.isfinite(k2)], self.weights[np.isfinite(k2)])],
-                              columns=['Average', 'SD', 'SE'], index=['k2', 'Estatic', 'Edynamic1', 'Edynamic2'])
+            df = pd.DataFrame([self.weightedAvgSDSE(k2[np.isfinite(k2)], weights[np.isfinite(k2)]),
+                               self.weightedAvgSDSE(estatic[np.isfinite(k2)], weights[np.isfinite(k2)]),
+                               self.weightedAvgSDSE(edynamic1[np.isfinite(k2)], weights[np.isfinite(k2)]),
+                               self.weightedAvgSDSE(edynamic2[np.isfinite(k2)], weights[np.isfinite(k2)])],
+                               columns=['Average', 'SD', 'SE'], index=['k2', 'Estatic', 'Edynamic1', 'Edynamic2'])
 
         logging.debug(f'Effective fraction of frames contributing to average: {self.fraction_frames()}')
 
         # Save DataFrame in pickle format
-        df.to_pickle(output_reweight_prefix + '-data-{:d}-{:d}.pkl'.format(self.residues[0], self.residues[1]))
+        df.to_pickle(reweight_output_prefix + '-data-{:d}-{:d}.pkl'.format(self.residues[0], self.residues[1]))
 
     def reweight(self, **kwargs):
 
@@ -620,26 +593,24 @@ class FRETpredict(Operations):
 
         """
 
-        output_reweight_prefix = kwargs.get('reweight_prefix', self.output_prefix)
+        reweight_output_prefix = kwargs.get('reweight_output_prefix', self.output_prefix)
+
+        # Reweight based on dye-protein energies?
+        boltzmann_weights = kwargs.get('boltzmann_weights', False)
 
         # User-provided per-frame weights
         user_weights = kwargs.get('user_weights', None)
 
-        # Dye-protein weights from FRETpredict calculations
-        dye_protein_weights = np.genfromtxt(
-                self.output_prefix + '-w_s-{:d}-{:d}.dat'.format(self.residues[0], self.residues[1]))
-
         # Normalized per-frame weights combining dye-protein and user provided weights
-        if user_weights is None:
-
+        if boltzmann_weights:
+            # Dye-protein weights from FRETpredict calculations
+            dye_protein_weights = np.genfromtxt(
+                    self.output_prefix + '-w_s-{:d}-{:d}.dat'.format(self.residues[0], self.residues[1]))
             self.weights = dye_protein_weights
-
         elif user_weights is not None:
+            self.user_weights = user_weights
 
-            self.weights = (dye_protein_weights * user_weights) / np.linalg.norm(dye_protein_weights * user_weights,
-                                                                                 ord=1)
-
-        self.save(reweight_prefix=output_reweight_prefix)
+        self.save(reweight_output_prefix=reweight_output_prefix)
 
     def run(self):
 

--- a/FRETpredict/__init__.py
+++ b/FRETpredict/__init__.py
@@ -4,6 +4,6 @@ from .utils import Operations
 from .lennardjones import lj_parameters
 from .libraries import *
 
-__version__ = '0.2.7'
+__version__ = '0.2.8'
 
 

--- a/README.md
+++ b/README.md
@@ -119,21 +119,22 @@ FRET = FRETpredict(protein=u, residues=[0, 12], chains=['A', 'A'], temperature=2
 FRET.run()
 
 ```
-Compute reweighted FRET efficiency based on protein-dye interactions
+Here is how to reweight the trajectory by per-frame dye-protein weights. 
 
 ```python
 
 FRET.reweight(boltzmann_weights=True, reweight_output_prefix='E_pp11_reweighted')
 
 ```
-and combine user-provided weights (numpy array) from previous calculations (e.g., Enhanced sampling simulations)
+Per-frame dye-protein weights can be combined with user-provided weights (numpy array) from previous calculations (e.g., Enhanced sampling simulations), which are passed as a numpy array to the `user_weights` attribute.
 
 ```python
 
 FRET.reweight(boltzmann_weights=True, user_weights=user_weights_pp11, reweight_output_prefix='E_pp11_reweighted')
 
 ```
-User-provided weights alone can be used to reweight the ensemble. In this case Boltzmann weights are not used and only frames with steric clashes between dye and protein are discarded
+
+User-provided weights alone can be used to reweight the ensemble. In this case Boltzmann weights are not used and only frames with steric clashes between dye and protein are discarded (default behaviour).
 
 ```python
 

--- a/README.md
+++ b/README.md
@@ -123,14 +123,21 @@ Compute reweighted FRET efficiency based on protein-dye interactions
 
 ```python
 
-FRET.reweight(reweight_prefix='E_pp11_reweighted')
+FRET.reweight(boltzmann_weights=True, reweight_output_prefix='E_pp11_reweighted')
 
 ```
-and combine user-provided weights from previous calculations (e.g., Enhanced sampling simulations)
+and combine user-provided weights (numpy array) from previous calculations (e.g., Enhanced sampling simulations)
 
 ```python
 
-FRET.reweight(reweight_prefix='E_pp11_reweighted', user_weights=user_weights_pp11)
+FRET.reweight(boltzmann_weights=True, user_weights=user_weights_pp11, reweight_output_prefix='E_pp11_reweighted')
+
+```
+User-provided weights alone can be used to reweight the ensemble. In this case Boltzmann weights are not used and only frames with steric clashes between dye and protein are discarded
+
+```python
+
+FRET.reweight(boltzmann_weights=False, user_weights=user_weights_pp11, reweight_output_prefix='E_pp11_reweighted')
 
 ```
 

--- a/docs/_docs/running.md
+++ b/docs/_docs/running.md
@@ -28,14 +28,18 @@ The program generates the pickle file named `E_pp11-data-0-12.pkl` which can be 
 
 Here is how to reweight the trajectory by per-frame dye-protein weights. 
 ~~~ python
-FRET.reweight(reweight_prefix='E_pp11_reweighted')
+FRET.reweight(boltzmann_weights=True, reweight_output_prefix='E_pp11_reweighted')
 ~~~
-and combine the with user-provided weights from previous calculations (e.g., Enhanced sampling simulations)
+Per-frame dye-protein weights can be combined with user-provided weights (numpy array) from previous calculations (e.g., Enhanced sampling simulations), which are passed as a numpy array to the `user_weights` attribute.
 ~~~ python
-FRET.reweight(reweight_prefix='E_pp11_reweighted', user_weights=user_weights_pp11)
+FRET.reweight(boltzmann_weights=True, user_weights=user_weights_pp11, reweight_output_prefix='E_pp11_reweighted')
+~~~
+User-provided weights alone can be used to reweight the ensemble. In this case Boltzmann weights are not used and only frames with steric clashes between dye and protein are discarded (default behaviour).
+~~~ python
+FRET.reweight(boltzmann_weights=False, user_weights=user_weights_pp11, reweight_output_prefix='E_pp11_reweighted')
 ~~~
 
-This generates the pickle file named `E_pp11_reweighted-data-0-12.pkl` with all the reweighted parameters, which can be loaded as a pandas DataFrame.
+Each of these lines generates a pickle file named `E_pp11_reweighted-data-0-12.pkl` with all the reweighted parameters, which can be loaded as a pandas DataFrame.
 
 In this other example, we can directly obtain the reweighted FRET efficiencies combining the dye-protein weights with custom pre-computed weights, which are passed as a numpy array to the `user_weights` attribute in the `FRETpredict` class.
 
@@ -46,6 +50,7 @@ FRET = FRETpredict(protein=u, residues=[0, 12], chains=['A', 'A'], temperature=2
                    donor='AlexaFluor 488', acceptor='AlexaFluor 594', electrostatic=True,
                    libname_1=f'AlexaFluor 488 C1R cutoff10',
                    libname_2=f'AlexaFluor 594 C1R cutoff10',  
+                   boltzmann_weights=True,
                    user_weights=user_weights_pp11,
                    output_prefix='E_pp11_reweighted')
 ~~~

--- a/tests/test_Hsp90.py
+++ b/tests/test_Hsp90.py
@@ -24,13 +24,19 @@ def test_Hsp90_R0_calculation():
                    output_prefix='tests/test_systems/Hsp90/output/E30',
                    verbose=True)
 
+    eff = []
+
     # Run FRETpredict calculations
     FRET.run()
+    eff.append(pd.read_pickle('tests/test_systems/Hsp90/output/E30-data-452-637.pkl')['Estatic'])
+
+    # Reweight FRETpredict calculations
+    FRET.reweight(user_weights=np.asarray([0.5]))
+    eff.append(pd.read_pickle('tests/test_systems/Hsp90/output/E30-data-452-637.pkl')['Estatic'])
 
     # Read computed data from file
-    print(pd.read_pickle('tests/test_systems/Hsp90/output/E30-data-452-637.pkl')['Estatic'])
-    assert np.abs(pd.read_pickle('tests/test_systems/Hsp90/output/E30-data-452-637.pkl')['Estatic'] - 0.467) < 1e-3,  \
-    "Could not read FRET data from file (explicit R0 calculations)"
+    print(eff)
+    assert np.allclose(eff,0.46766,rtol=0,atol=1E-05)
 
 # Test with single frame, fixed R0 value
 def test_Hsp90_fixed_R0():
@@ -47,11 +53,16 @@ def test_Hsp90_fixed_R0():
                            output_prefix='tests/test_systems/Hsp90/output/E30_fixedR0',
                            verbose=True)
 
+    eff = []
+
     # Run FRETpredict calculations
     FRET_fixedR0.run()
+    eff.append(pd.read_pickle('tests/test_systems/Hsp90/output/E30_fixedR0-data-452-637.pkl')['Estatic'])
+
+    # Reweight FRETpredict calculations
+    FRET_fixedR0.reweight(user_weights=np.asarray([0.5]))
+    eff.append(pd.read_pickle('tests/test_systems/Hsp90/output/E30_fixedR0-data-452-637.pkl')['Estatic'])
 
     # Read computed data from file
-    print(pd.read_pickle('tests/test_systems/Hsp90/output/E30_fixedR0-data-452-637.pkl')['Estatic'])
-    assert np.abs(pd.read_pickle('tests/test_systems/Hsp90/output/E30_fixedR0-data-452-637.pkl')['Estatic'] - 0.538) < 1e-3,  \
-    "Could not read FRET data from file (fixed R0)"
-
+    print(eff)
+    assert np.allclose(eff,0.53814,rtol=0,atol=1E-05)


### PR DESCRIPTION
### New Features:
- **`calc_distr` option** (default: `False`):  
   - When `calc_distr` is set to `False`, **histograms** of dye-dye distances and the orientation factor are **not** calculated. This improves performance and reduces memory usage.  
   - To recover the previous behavior, set `calc_distr` to `True`.  

- **`boltzmann_weights` option** (default: `False`):  
   - When `boltzmann_weights` is set to `False`, **Boltzmann weights** based on protein-dye interactions are **not** used to reweight frames. However, frames with steric clashes between the dye and protein are still discarded.  
   - If `boltzmann_weights` is set to `True` and user-defined weights are provided, **Boltzmann weights** based on protein-dye interactions are combined with the user-defined weights. 
   - If `boltzmann_weights` is set to `False` and user-defined weights are provided, only user-defined weights are used to reweight the frames while frames with steric clashes between the dye and protein are still discarded.  
   - To recover the previous behavior, set `boltzmann_weights` to `True`. 

